### PR TITLE
Added logic to process pods whose geolocation are empty

### DIFF
--- a/globalscheduler/cmd/BUILD
+++ b/globalscheduler/cmd/BUILD
@@ -10,6 +10,7 @@ filegroup(
     srcs = [
         ":package-srcs",
         "//globalscheduler/cmd/dispatcher_process:all-srcs",
+        "//globalscheduler/cmd/distributor:all-srcs",
         "//globalscheduler/cmd/distributor_process:all-srcs",
         "//globalscheduler/cmd/grpc-server:all-srcs",
         "//globalscheduler/cmd/gs-controllers:all-srcs",

--- a/globalscheduler/controllers/dispatcher/dispatcher_process.go
+++ b/globalscheduler/controllers/dispatcher/dispatcher_process.go
@@ -199,7 +199,7 @@ func (p *Process) SendPodToCluster() {
 			if err == nil {
 				klog.V(3).Infof("Creating request for pod %v has been sent to %v", pod.ObjectMeta.Name, host)
 				pod.Spec.Hostname = instanceId
-				pod.Status.Phase = v1.PodRunning
+				pod.Status.Phase = v1.PodScheduled
 				updatedPod, err := p.clientset.CoreV1().Pods(pod.ObjectMeta.Namespace).Update(pod)
 				if err == nil {
 					klog.V(3).Infof("Creating request for pod %v returned successfully with %v", updatedPod, instanceId)

--- a/globalscheduler/controllers/dispatcher/dispatcher_process.go
+++ b/globalscheduler/controllers/dispatcher/dispatcher_process.go
@@ -199,7 +199,7 @@ func (p *Process) SendPodToCluster() {
 			if err == nil {
 				klog.V(3).Infof("Creating request for pod %v has been sent to %v", pod.ObjectMeta.Name, host)
 				pod.Spec.Hostname = instanceId
-				pod.Status.Phase = v1.PodScheduled
+				pod.Status.Phase = v1.ClusterScheduled
 				updatedPod, err := p.clientset.CoreV1().Pods(pod.ObjectMeta.Namespace).Update(pod)
 				if err == nil {
 					klog.V(3).Infof("Creating request for pod %v returned successfully with %v", updatedPod, instanceId)

--- a/globalscheduler/controllers/distributor/BUILD
+++ b/globalscheduler/controllers/distributor/BUILD
@@ -17,7 +17,6 @@ go_library(
         "//globalscheduler/pkg/apis/distributor/v1:go_default_library",
         "//globalscheduler/pkg/apis/scheduler/client/clientset/versioned:go_default_library",
         "//globalscheduler/pkg/apis/scheduler/client/informers/externalversions:go_default_library",
-        "//globalscheduler/pkg/apis/scheduler/client/listers/scheduler/v1:go_default_library",
         "//globalscheduler/pkg/apis/scheduler/v1:go_default_library",
         "//pkg/controller:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -2418,8 +2418,8 @@ const (
 	PodAssigned PodPhase = "Assigned"
 	// PodBound means that the pod has a cluster bound to.
 	PodBound PodPhase = "Bound"
-	// PodScheduled means that openstack vms has been created for the pod
-	PodScheduled PodPhase = "Scheduled"
+	// ClusterScheduled means that openstack vms has been created for the pod
+	ClusterScheduled PodPhase = "Scheduled"
 )
 
 type PodConditionType string

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -2418,6 +2418,8 @@ const (
 	PodAssigned PodPhase = "Assigned"
 	// PodBound means that the pod has a cluster bound to.
 	PodBound PodPhase = "Bound"
+	// PodScheduled means that openstack vms has been created for the pod
+	PodScheduled PodPhase = "Scheduled"
 )
 
 type PodConditionType string

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2662,8 +2662,8 @@ const (
 	PodAssigned PodPhase = "Assigned"
 	// PodBound means that the pod has a cluster bound to.
 	PodBound PodPhase = "Bound"
-	// PodScheduled means that openstack vms has been created for the pod
-	PodScheduled PodPhase = "Scheduled"
+	// ClusterScheduled means that openstack vms has been created for the pod
+	ClusterScheduled PodPhase = "Scheduled"
 )
 
 // PodConditionType is a valid value for PodCondition.Type

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2662,6 +2662,8 @@ const (
 	PodAssigned PodPhase = "Assigned"
 	// PodBound means that the pod has a cluster bound to.
 	PodBound PodPhase = "Bound"
+	// PodScheduled means that openstack vms has been created for the pod
+	PodScheduled PodPhase = "Scheduled"
 )
 
 // PodConditionType is a valid value for PodCondition.Type

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -109,6 +109,12 @@ type Reflector struct {
 
 	// There are some watch that can only happen to certain api servers
 	allowPartialWatch bool
+
+	// selectorCh is a channel having selector input
+	selectorCh <-chan string
+
+	//s selector is a string for field selectors
+	selector string
 }
 
 var (
@@ -148,6 +154,19 @@ func NewReflectorWithReset(lw ListerWatcher, expectedType interface{}, store Sto
 	return r
 }
 
+// NewReflectorWithResetCh creates a new Reflector object which will keep the given store up to
+// date with the server's contents for the given resource. Reflector promises to
+// only put things in the store that have the type of expectedType, unless expectedType
+// is nil. If resyncPeriod is non-zero, then lists will be executed after every
+// resyncPeriod, so that you can use reflectors to periodically process everything as
+// well as incrementally processing the things that change. selectorCh is used to input
+// new selector to restart the reflector
+func NewReflectorWithSelectorCh(lw ListerWatcher, expectedType interface{}, store Store, resyncPeriod time.Duration, selectorCh <-chan string) *Reflector {
+	r := NewNamedReflector(naming.GetNameFromCallsite(internalPackages...), lw, expectedType, store, resyncPeriod, false)
+	r.selectorCh = selectorCh
+	return r
+}
+
 // NewNamedReflector same as NewReflector, but with a specified name for logging
 func NewNamedReflector(name string, lw ListerWatcher, expectedType interface{}, store Store, resyncPeriod time.Duration, allowPartialWatch bool) *Reflector {
 	r := &Reflector{
@@ -163,6 +182,7 @@ func NewNamedReflector(name string, lw ListerWatcher, expectedType interface{}, 
 		clientSetUpdateChan:     apiserverupdate.WatchClientSetUpdate(),
 		listFromResourceVersion: "0",
 		allowPartialWatch:       allowPartialWatch,
+		selectorCh:              nil,
 	}
 	return r
 }
@@ -180,6 +200,8 @@ func (r *Reflector) Run(stopCh <-chan struct{}) {
 			if err := r.ListAndWatch(stopCh); err != nil {
 				utilruntime.HandleError(err)
 			}
+		} else if r.selectorCh != nil {
+
 		} else {
 			for i, fb := range r.filterBounds {
 				go func(index int, fB filterBound) {
@@ -231,6 +253,9 @@ var (
 
 	// Used to indicate that watching stopped because api server clients are updated
 	errorClientSetResetRequested = errors.New("Clientset reset requested")
+
+	// Used to indicate that watching stopped because filter selectors are updated
+	errorResetFilterSelectorRequested = errors.New("Filter Selector Reset requested")
 )
 
 // resyncChan returns a channel which will receive something when a resync is
@@ -276,6 +301,21 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 
 		// Pick up any bound changes
 		options = appendFieldSelector(options, r.createHashkeyListOptions())
+	}
+
+	if r.selectorCh != nil {
+		if !r.waitForSelector(stopCh) {
+			return nil
+		} else {
+			select {
+			case <-stopCh:
+				return nil
+			default:
+				klog.V(4).Infof("ListAndWatchWithReset default fall through. selector %+v", r.selector)
+			}
+		}
+		// Pick up any selector changes
+		options = appendFieldSelector(options, metav1.ListOptions{FieldSelector: r.selector})
 	}
 
 	// LIST
@@ -395,6 +435,10 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 		if len(r.filterBounds) > 0 {
 			options = appendFieldSelector(options, r.createHashkeyListOptions())
 		}
+		if r.selectorCh != nil {
+			options = appendFieldSelector(options, metav1.ListOptions{FieldSelector: r.selector})
+		}
+
 		aggregatedWatcher := r.listerWatcher.Watch(options)
 		err := aggregatedWatcher.GetErrors()
 		if err != nil {
@@ -422,7 +466,7 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 		}
 
 		if err := r.watchHandler(aggregatedWatcher, &resourceVersion, resyncerrc, stopCh); err != nil {
-			if err == errorResetFilterBoundRequested || err == errorClientSetResetRequested {
+			if err == errorResetFilterBoundRequested || err == errorResetFilterSelectorRequested || err == errorClientSetResetRequested {
 				select {
 				case cancelCh <- struct{}{}:
 					klog.V(4).Infof("Sent message to Resync cancelCh.")
@@ -488,6 +532,34 @@ loop:
 				r.setBounds(signal)
 
 				return errorResetFilterBoundRequested
+			case err := <-errc:
+				return err
+			case event, ok := <-w.ResultChan():
+				if !ok {
+					break loop
+				}
+
+				var err error
+				err, eventCount = r.watchHandlerHelper(event, resourceVersion, eventCount)
+				if err != nil {
+					return err
+				}
+			}
+		} else if r.selectorCh != nil {
+			select {
+			case <-r.clientSetUpdateChan.Read:
+				klog.Infof("Got client set update message. Restarting ListAndWatch %v", r.expectedType)
+				return errorClientSetResetRequested
+			case <-stopCh:
+				return errorStopRequested
+			case signal, ok := <-r.selectorCh:
+				if !ok {
+					klog.Error("selector channel closed")
+					return errors.New("selector channel closed")
+				}
+				r.selector = signal
+
+				return errorResetFilterSelectorRequested
 			case err := <-errc:
 				return err
 			case event, ok := <-w.ResultChan():
@@ -650,6 +722,30 @@ func (r *Reflector) waitForBoundInit(stopCh <-chan struct{}) bool {
 			return true
 		} else {
 			klog.V(4).Infof("Waiting for more init bound. expectedType %v, Bounds: %+v", r.expectedType, r.filterBounds)
+		}
+	}
+}
+
+// return false if selectorCh sends new selector
+func (r *Reflector) waitForSelector(stopCh <-chan struct{}) bool {
+	for {
+		select {
+		case msg, ok := <-r.selectorCh:
+			if !ok {
+				klog.Errorf("Cannot read from closed channel. expectedType %v", r.expectedType)
+				return false
+			}
+			r.selector = msg
+			fmt.Printf("****The new input selector is %s\n", r.selector)
+		case <-stopCh:
+			return false
+		}
+
+		if len(r.selector) > 0 {
+			klog.V(4).Infof("Update selector succeeded. expectedType %v, selector: %+v", r.expectedType, r.selector)
+			return true
+		} else {
+			klog.V(4).Infof("Waiting for selector. expectedType %v, selector: %+v", r.expectedType, r.selector)
 		}
 	}
 }

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -736,7 +736,6 @@ func (r *Reflector) waitForSelector(stopCh <-chan struct{}) bool {
 				return false
 			}
 			r.selector = msg
-			fmt.Printf("****The new input selector is %s\n", r.selector)
 		case <-stopCh:
 			return false
 		}

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -134,7 +134,6 @@ func NewSharedInformer(lw ListerWatcher, objType runtime.Object, resyncPeriod ti
 
 // NewSharedIndexInformer creates a new instance for the listwatcher.
 func NewSharedIndexInformer(lw ListerWatcher, objType runtime.Object, defaultEventHandlerResyncPeriod time.Duration, indexers Indexers) SharedIndexInformer {
-	fmt.Println("Informer")
 	realClock := &clock.RealClock{}
 
 	sharedIndexInformer := &sharedIndexInformer{
@@ -269,7 +268,6 @@ type deleteNotification struct {
 }
 
 func (s *sharedIndexInformer) Run(stopCh <-chan struct{}) {
-	fmt.Println("Running")
 	defer utilruntime.HandleCrash()
 
 	fifo := NewDeltaFIFO(MetaNamespaceKeyFunc, s.indexer)
@@ -306,7 +304,6 @@ func (s *sharedIndexInformer) Run(stopCh <-chan struct{}) {
 		defer s.startedLock.Unlock()
 		s.stopped = true // Don't want any new listeners
 	}()
-	fmt.Printf("************Run %v %v\n", len(s.filterBounds), s.selectorCh)
 	if len(s.filterBounds) > 0 {
 		klog.V(4).Infof("start informer with reset channel. %v", s.objectType)
 		s.controller.RunWithReset(stopCh, s.filterBounds)
@@ -371,7 +368,6 @@ func (s *sharedIndexInformer) AddResetCh(resetCh *bcast.Member, sourceName strin
 
 func (s *sharedIndexInformer) AddSelectorCh(selectorCh <-chan string) {
 	s.selectorCh = selectorCh
-	fmt.Printf("The AddSelectorCh is %v\n", s.selectorCh)
 }
 
 func (s *sharedIndexInformer) GetController() Controller {


### PR DESCRIPTION
I got a pod yaml files failed to get distributed. 

piVersion: v1
kind: Pod
metadata:
  name: samplepod1
spec:
  workloadInfo:
  - name: "pod1"
    image: "79ae45a7-5f72-4274-be83-9d982f8ba648"
    securityGroupId: "4f49dd81-5dcd-4f57-b7b4-66f04020497b"
  virtualMachine:
    name: "demo-vm"
    keyPairName: "demo-keypair"
    flavors:
    - flavorID: "3"
  nics:
  - name: "9a85f815-d83d-4104-9657-70a636072824"
  clusterName: "Apache1"

Debugged and found the reason that its resourceType has not been set to vm and geoLocation is empty.

To fix it, I add vm to the pod yaml files and add logic to process pods whose geolocation are empty.

During tests, I found that selectors are not well handled by adding ";". In order not to break the current logic, I added codes to process selector changes.