### PR TITLE
Fixed the issue that dispatchers failed to update due to sync. Rolled…

### DIFF
--- a/globalscheduler/cmd/scheduler_process/mock_scheduler/BUILD
+++ b/globalscheduler/cmd/scheduler_process/mock_scheduler/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/kubernetes/globalscheduler/cmd/scheduler_process/mock_scheduler",
     visibility = ["//visibility:public"],
     deps = [
+        "//globalscheduler/controllers/util:go_default_library",
         "//globalscheduler/pkg/apis/scheduler/client/clientset/versioned:go_default_library",
         "//globalscheduler/pkg/apis/scheduler/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/globalscheduler/controllers/distributor/BUILD
+++ b/globalscheduler/controllers/distributor/BUILD
@@ -9,6 +9,7 @@ go_library(
     importpath = "k8s.io/kubernetes/globalscheduler/controllers/distributor",
     visibility = ["//visibility:public"],
     deps = [
+        "//globalscheduler/controllers/util:go_default_library",
         "//globalscheduler/pkg/apis/cluster/v1:go_default_library",
         "//globalscheduler/pkg/apis/distributor:go_default_library",
         "//globalscheduler/pkg/apis/distributor/client/clientset/versioned:go_default_library",

--- a/resourcecollector/pkg/collector/rpc/pbfile/protoc.sh
+++ b/resourcecollector/pkg/collector/rpc/pbfile/protoc.sh
@@ -1,3 +1,18 @@
+/*
+Copyright 2020 Authors of Arktos.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 #! /bin/sh
 protoc --go_out=plugins=grpc:. cluster.proto
 protoc --go_out=plugins=grpc:. clusterstate.proto


### PR DESCRIPTION
There are 3 major changes

1. Fixed the issue that dispatchers failed to update their ranges due to synchronization latencies. So does distributors
2. Rolled back the changes to shared informers by removing selectorCh since it is not used any more.
3. Added performance time matrix to mock schedulers.